### PR TITLE
Use TO_DATE placeholders in query builder

### DIFF
--- a/data/query_builder.py
+++ b/data/query_builder.py
@@ -1,6 +1,28 @@
 
+"""Helpers to construct SQL queries with date filters."""
+
+
 def build_query(fecha_ini, fecha_fin):
-    with open("sql/base_query.sql", "r") as f:
-        base_query = f.read()
-    filtro = f"\nWHERE a.pri_action_date BETWEEN TO_DATE('{fecha_ini.strftime('%Y-%m-%d %H:%M:%S')}', 'YYYY-MM-DD HH24:MI:SS') AND TO_DATE('{fecha_fin.strftime('%Y-%m-%d %H:%M:%S')}', 'YYYY-MM-DD HH24:MI:SS')"
-    return base_query + filtro
+    """Load base SQL and inject formatted dates.
+
+    The base query contains the placeholders ``:fecha_ini`` and
+    ``:fecha_fin``. This function replaces those placeholders with Oracle
+    ``TO_DATE`` expressions formatted as ``YYYY-MM-DD HH24:MI:SS``.
+    """
+
+    with open("sql/base_query.sql", "r", encoding="utf-8") as f:
+        query = f.read()
+
+    fecha_ini_str = fecha_ini.strftime("%Y-%m-%d %H:%M:%S")
+    fecha_fin_str = fecha_fin.strftime("%Y-%m-%d %H:%M:%S")
+
+    query = query.replace(
+        ":fecha_ini",
+        f"TO_DATE('{fecha_ini_str}', 'YYYY-MM-DD HH24:MI:SS')",
+    )
+    query = query.replace(
+        ":fecha_fin",
+        f"TO_DATE('{fecha_fin_str}', 'YYYY-MM-DD HH24:MI:SS')",
+    )
+
+    return query


### PR DESCRIPTION
## Summary
- Replace concatenated WHERE clause by substituting :fecha_ini and :fecha_fin placeholders with TO_DATE expressions

## Testing
- `python -m py_compile data/query_builder.py`
- `python - <<'PY'
from datetime import datetime
from data.query_builder import build_query
q = build_query(datetime(2023,1,1,0,0,0), datetime(2023,1,2,23,59,59))
print(q)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68928f1fe83c832c8828341c2217c543