### PR TITLE
Normalize transaction column names

### DIFF
--- a/services/data_service.py
+++ b/services/data_service.py
@@ -1,5 +1,8 @@
-
 import pandas as pd
 
+
 def get_transacciones(conn, query):
-    return pd.read_sql(query, conn)
+    """Retrieve transactions and normalize column names."""
+    df = pd.read_sql(query, conn)
+    df.columns = df.columns.str.lower()
+    return df


### PR DESCRIPTION
## Summary
- Normalize column names from database queries to lower-case in `get_transacciones` for consistent downstream references.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68934b6296d4832caf416c70dd994112