### PR TITLE
Replace HTML KPI cards with Streamlit metrics

### DIFF
--- a/visualizations/charts.py
+++ b/visualizations/charts.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import plotly.express as px
 
+
 def kpi_cards(df):
     total = len(df)
     ok = len(df[df["pri_status"] == "O"])
@@ -8,17 +9,28 @@ def kpi_cards(df):
     perc_ok = (ok / total) * 100 if total > 0 else 0
     perc_err = (error / total) * 100 if total > 0 else 0
 
+    if total == 0:
+        st.warning("No data available")
+
     col1, col2, col3 = st.columns(3)
-    col1.markdown(f"<div style='padding:20px; background:#e8f5e9; border-radius:10px'><h3>Total</h3><h1>{total}</h1></div>", unsafe_allow_html=True)
-    col2.markdown(f"<div style='padding:20px; background:#e3f2fd; border-radius:10px'><h3>% OK</h3><h1>{perc_ok:.2f}%</h1></div>", unsafe_allow_html=True)
-    col3.markdown(f"<div style='padding:20px; background:#ffebee; border-radius:10px'><h3>% Error</h3><h1>{perc_err:.2f}%</h1></div>", unsafe_allow_html=True)
+    col1.metric("Total", total)
+    col2.metric("% OK", f"{perc_ok:.2f}%")
+    col3.metric("% Error", f"{perc_err:.2f}%")
+
 
 def status_pie_chart(df):
-    counts = df['pri_status'].value_counts().reset_index()
-    counts.columns = ['Status', 'Cantidad']
-    return px.pie(counts, names='Status', values='Cantidad', title="Distribución de Status")
+    if df.empty:
+        st.warning("No data available")
+        return px.Figure()
+    counts = df["pri_status"].value_counts().reset_index()
+    counts.columns = ["Status", "Cantidad"]
+    return px.pie(counts, names="Status", values="Cantidad", title="Distribución de Status")
+
 
 def error_bar_chart(df):
+    if df.empty:
+        st.warning("No data available")
+        return px.Figure()
     errores = df[df["pri_status"] == "E"]
     conteo = errores["pri_error_code"].value_counts().reset_index()
     conteo.columns = ["Código Error", "Cantidad"]


### PR DESCRIPTION
## Summary
- Replace HTML-based KPI cards with `st.metric` widgets
- Warn when datasets are empty before building KPI/Chart visuals

## Testing
- `python -m py_compile visualizations/charts.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68935821c08c832cb64498a4cb96fdc5