### PR TITLE
Add transaction detail page

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,7 @@ with col3:
 # Ejecutar consulta
 query = build_query(fecha_ini, fecha_fin, ne_id or None)
 df = get_transacciones(st.session_state["db_conn"], query)
+st.session_state["transacciones_df"] = df
 
 # Logs detallados
 st.write("📋 Log de ejecución")
@@ -61,14 +62,8 @@ st.success(f"Total de transacciones recuperadas: {len(df)}")
 # KPIs
 kpi_cards(df)
 
-# Tabla de transacciones
-st.subheader("📄 Detalle de transacciones")
-max_cols = 10
-data_to_show = df[df.columns[:max_cols]] if len(df.columns) > max_cols else df
-if HAS_AGGRID:
-    AgGrid(data_to_show)
-else:
-    st.dataframe(data_to_show)
+if st.button("Ver detalle de transacciones"):
+    st.switch_page("pages/detalle_transacciones")
 
 # Pie chart
 st.plotly_chart(status_pie_chart(df), use_container_width=True)

--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -1,0 +1,23 @@
+import streamlit as st
+
+try:
+    from st_aggrid import AgGrid
+    HAS_AGGRID = True
+except ImportError:
+    HAS_AGGRID = False
+
+st.set_page_config(page_title="Detalle de transacciones")
+st.title("📄 Detalle de transacciones")
+
+df = st.session_state.get("transacciones_df")
+
+if df is None:
+    st.warning("No hay datos de transacciones en la sesión")
+else:
+    if HAS_AGGRID:
+        AgGrid(df)
+    else:
+        st.dataframe(df)
+
+if st.button("Volver"):
+    st.switch_page("app")


### PR DESCRIPTION
## Summary
- Persist transaction query results in session state
- Replace inline table with navigation button to a new detail page
- Show transactions on a dedicated page with back navigation

## Testing
- `python -m py_compile app.py pages/detalle_transacciones.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68937e94b444832ca778fcc3d316f80e