### PR TITLE
Ocultar navegación lateral y header

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,15 @@ except ImportError:
     HAS_AGGRID = False
 
 st.set_page_config(page_title="Dashboard Provisioning", layout="wide")
+st.markdown(
+    """
+    <style>
+    div[data-testid='stSidebarNav'] { display: none; }
+    [data-testid='stHeader'] { display: none; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 st.title("📊 Dashboard Provisioning")
 
 # Configuración de conexión

--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -7,6 +7,15 @@ except ImportError:
     HAS_AGGRID = False
 
 st.set_page_config(page_title="Detalle de transacciones")
+st.markdown(
+    """
+    <style>
+    div[data-testid='stSidebarNav'] { display: none; }
+    [data-testid='stHeader'] { display: none; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 st.title("📄 Detalle de transacciones")
 
 df = st.session_state.get("transacciones_df")


### PR DESCRIPTION
## Summary
- Ocultar barra lateral y encabezado de Streamlit con CSS en app principal
- Aplicar el mismo estilo en la página de detalle de transacciones

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68939cdf2580832c8008ac7bcfe93eec