### PR TITLE
Add status and error filtering to transaction details

### DIFF
--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -23,10 +23,21 @@ df = st.session_state.get("transacciones_df")
 if df is None:
     st.warning("No hay datos de transacciones en la sesión")
 else:
+    estados = ["Todos"] + df["pri_status"].dropna().unique().tolist()
+    estado = st.selectbox("Filtrar por estado", estados)
+
+    df_filtrado = df if estado == "Todos" else df[df["pri_status"] == estado]
+
+    if estado == "E":
+        errores = ["Todos"] + df_filtrado["pri_error_code"].dropna().unique().tolist()
+        error = st.selectbox("Tipo de error", errores)
+        if error != "Todos":
+            df_filtrado = df_filtrado[df_filtrado["pri_error_code"] == error]
+
     if HAS_AGGRID:
-        AgGrid(df)
+        AgGrid(df_filtrado)
     else:
-        st.dataframe(df)
+        st.dataframe(df_filtrado)
 
 if st.button("Volver"):
     st.switch_page("app.py")


### PR DESCRIPTION
## Summary
- allow filtering transactions by status with a selectbox
- add optional error code filter when status is `E`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a94f7064832ca5c42b71081e8028