### PR TITLE
Compute pri_id dynamically in insert generator

### DIFF
--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -46,15 +46,17 @@ else:
         inserts = []
         for _, fila in df_filtrado.iterrows():
             valores = []
-            for valor in fila:
-                if pd.isna(valor):
+            for col, valor in fila.items():
+                if col.lower() == "pri_id":
+                    valores.append("(SELECT MAX(pri_id) + 1 FROM swp_provisioning_interfaces)")
+                elif pd.isna(valor):
                     valores.append("NULL")
                 elif isinstance(valor, str):
                     valores.append("'" + valor.replace("'", "''") + "'")
                 else:
                     valores.append(str(valor))
             inserts.append(
-                f"INSERT INTO swp_provisioning_interfaces ({columnas}) VALUES ({', '.join(valores)});"
+                f"INSERT INTO swp_provisioning_interfaces ({columnas}) VALUES ({', '.join(valores)});",
             )
 
         sql_contenido = "\n".join(inserts)


### PR DESCRIPTION
## Summary
- Use `(SELECT MAX(pri_id) + 1 FROM swp_provisioning_interfaces)` when building SQL inserts so new pri_id values are generated iteratively

## Testing
- `pytest`
- `python -m py_compile pages/detalle_transacciones.py`


------
https://chatgpt.com/codex/tasks/task_e_6893b8fbc354832c9d0fddec1844c60f