### PR TITLE
Handle SYSDATE directly in insert generation

### DIFF
--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -58,7 +58,7 @@ else:
                     or isinstance(valor, (pd.Timestamp, datetime.datetime, datetime.date))
                 ):
                     if isinstance(valor, str) and valor.upper() == "SYSDATE":
-                        valores.append("TO_DATE(SYSDATE, 'DD-MM-YYYY HH24:MI:SS')")
+                        valores.append("SYSDATE")
                     else:
                         fecha = pd.to_datetime(valor)
                         valores.append(


### PR DESCRIPTION
## Summary
- Use `SYSDATE` directly for timestamp columns when the source value is the literal string "SYSDATE"
- Preserve existing formatting for other date values

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893e5976a8c832ca0c0908c361beae1