### PR TITLE
Handle missing pri_id values with NVL

### DIFF
--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -49,7 +49,9 @@ else:
             valores = []
             for col, valor in fila.items():
                 if col.lower() == "pri_id":
-                    valores.append("(SELECT MAX(pri_id) + 1 FROM swp_provisioning_interfaces)")
+                    valores.append(
+                        "(SELECT NVL(MAX(pri_id), 0) + 1 FROM swp_provisioning_interfaces)"
+                    )
                 elif pd.isna(valor):
                     valores.append("NULL")
                 elif (


### PR DESCRIPTION
## Summary
- ensure generated INSERT statements use NVL(MAX(pri_id),0)+1 for pri_id

## Testing
- `python -m py_compile pages/detalle_transacciones.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893f693593c832cb82cefa5d1a8066e