### PR TITLE
Sanitize pri_request for SQL inserts

### DIFF
--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -66,6 +66,9 @@ else:
                         valores.append(
                             f"TO_DATE('{fecha.strftime('%d-%m-%Y %H:%M:%S')}', 'DD-MM-YYYY HH24:MI:SS')"
                         )
+                elif col.lower() == "pri_request":
+                    texto = str(valor).replace("\n", "").replace("\r", "")
+                    valores.append("'" + texto.replace("'", "''") + "'")
                 elif isinstance(valor, str):
                     valores.append("'" + valor.replace("'", "''") + "'")
                 else:


### PR DESCRIPTION
## Summary
- Remove newline and carriage return characters from `pri_request` before generating SQL inserts
- Preserve escaping of single quotes to keep `pri_request` safe for SQL

## Testing
- `python -m py_compile pages/detalle_transacciones.py`
- Manually generated example inserts to verify `pri_request` output formatting

------
https://chatgpt.com/codex/tasks/task_e_6893fdfa8c10832ca1e660302d4af9b9