### PR TITLE
Ensure valid connection before using database

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,17 +32,19 @@ with st.sidebar:
     user = st.text_input("Usuario")
     password = st.text_input("Contraseña", type="password")
     if st.button("Conectar"):
-        st.session_state["connection_name"] = f"{host}:{port}/{service_name}"
         conn = get_connection(host, port, service_name, user, password)
         if conn:
+            st.session_state["connection_name"] = f"{host}:{port}/{service_name}"
+            st.session_state["db_conn"] = conn
             st.success(f"✅ Conectado a {st.session_state['connection_name']}")
+        else:
+            st.error("❌ No se pudo establecer la conexión")
 
 # Mostrar log de conexión
-if "connection_name" in st.session_state:
-    st.info(f"🔗 Conectado a: {st.session_state['connection_name']}")
-else:
+if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
     st.stop()
+st.info(f"🔗 Conectado a: {st.session_state['connection_name']}")
 
 # Parámetros de fecha
 now = datetime.datetime.now()
@@ -59,10 +61,16 @@ with col3:
     ne_id = st.text_input("NE ID")
     action = None
     if ne_id:
+        if "db_conn" not in st.session_state:
+            st.warning("🔌 No hay conexión activa")
+            st.stop()
         actions = get_actions(st.session_state["db_conn"], ne_id)
         action = st.selectbox("Acción", actions)
 
 # Ejecutar consulta
+if "db_conn" not in st.session_state:
+    st.warning("🔌 No hay conexión activa")
+    st.stop()
 query = build_query(fecha_ini, fecha_fin, ne_id or None, action)
 df = get_transacciones(st.session_state["db_conn"], query)
 st.session_state["transacciones_df"] = df


### PR DESCRIPTION
## Summary
- Guard database operations behind a `db_conn` check to prevent usage without a valid connection.
- Set `connection_name` only after `get_connection` succeeds and show error otherwise.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894013f4c9c832c95e2057632d3bee1