### PR TITLE
Add multi-action filter to dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,19 +64,19 @@ with col2:
     fecha_fin = datetime.datetime.combine(fecha_fin_fecha, fecha_fin_hora)
 with col3:
     ne_id = st.text_input("NE ID")
-    action = None
+    actions_selected = []
     if ne_id:
         if "db_conn" not in st.session_state:
             st.warning("🔌 No hay conexión activa")
             st.stop()
         actions = get_actions(st.session_state["db_conn"], ne_id)
-        action = st.selectbox("Acción", actions)
+        actions_selected = st.multiselect("Acción", actions)
 
 # Ejecutar consulta
 if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
     st.stop()
-query = build_query(fecha_ini, fecha_fin, ne_id or None, action)
+query = build_query(fecha_ini, fecha_fin, ne_id or None, actions_selected or None)
 if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
     st.stop()

--- a/data/query_builder.py
+++ b/data/query_builder.py
@@ -5,14 +5,14 @@ DATE_FORMAT = "%d-%m-%Y %H:%M:%S"
 ORACLE_DATE_FORMAT = "DD-MM-YYYY HH24:MI:SS"
 
 
-def build_query(fecha_ini, fecha_fin=None, ne_id=None, action=None):
+def build_query(fecha_ini, fecha_fin=None, ne_id=None, actions=None):
     """Load base SQL and inject formatted filters.
 
     The base query contains the placeholders ``:fecha_ini`` and
     ``:fecha_fin``. This function replaces those placeholders with Oracle
     ``TO_DATE`` expressions formatted as ``DD-MM-YYYY HH24:MI:SS``. If
     ``fecha_fin`` is not provided, the ``:fecha_fin`` placeholder is
-    replaced with ``SYSDATE``. When ``ne_id`` or ``action`` are provided,
+    replaced with ``SYSDATE``. When ``ne_id`` or ``actions`` are provided,
     respective ``AND`` clauses are appended using the ``:ne_id`` and
     ``:action`` placeholders defined in ``sql/base_query.sql``.
     """
@@ -43,10 +43,11 @@ def build_query(fecha_ini, fecha_fin=None, ne_id=None, action=None):
     else:
         query = query.replace(":ne_id", "")
 
-    if action:
+    if actions:
+        formatted_actions = ", ".join(f"'{a}'" for a in actions)
         query = query.replace(
             ":action",
-            f"AND a.pri_action = '{action}'",
+            f"AND a.pri_action IN ({formatted_actions})",
         )
     else:
         query = query.replace(":action", "")


### PR DESCRIPTION
## Summary
- Replace single action selector with multiselect filter
- Support filtering by multiple actions in SQL query builder

## Testing
- `python -m pytest`
- `python - <<'PY'
from data.query_builder import build_query
from datetime import datetime
print(build_query(datetime(2024,1,1,0,0), datetime(2024,1,2,0,0), 'NE123', None))
print('---')
print(build_query(datetime(2024,1,1,0,0), datetime(2024,1,2,0,0), 'NE123', ['ACT1', 'ACT2']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_6894187c00e0832ca95cc3684528cb01