### PR TITLE
Allow filtering by multiple actions

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
     st.stop()
 
-    if "connection_name" in st.session_state:
+if "connection_name" in st.session_state:
     st.info(f"🔗 Conectado a: {st.session_state['connection_name']}")
 
 
@@ -64,19 +64,24 @@ with col2:
     fecha_fin = datetime.datetime.combine(fecha_fin_fecha, fecha_fin_hora)
 with col3:
     ne_id = st.text_input("NE ID")
-    action = None
+    selected_actions = None
     if ne_id:
         if "db_conn" not in st.session_state:
             st.warning("🔌 No hay conexión activa")
             st.stop()
         actions = get_actions(st.session_state["db_conn"], ne_id)
-        action = st.selectbox("Acción", actions)
+        selected_actions = st.multiselect("Acción", actions)
 
 # Ejecutar consulta
 if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
     st.stop()
-query = build_query(fecha_ini, fecha_fin, ne_id or None, action)
+query = build_query(
+    fecha_ini,
+    fecha_fin,
+    ne_id or None,
+    selected_actions or None,
+)
 if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
     st.stop()

--- a/data/query_builder.py
+++ b/data/query_builder.py
@@ -5,16 +5,16 @@ DATE_FORMAT = "%d-%m-%Y %H:%M:%S"
 ORACLE_DATE_FORMAT = "DD-MM-YYYY HH24:MI:SS"
 
 
-def build_query(fecha_ini, fecha_fin=None, ne_id=None, action=None):
+def build_query(fecha_ini, fecha_fin=None, ne_id=None, actions=None):
     """Load base SQL and inject formatted filters.
 
     The base query contains the placeholders ``:fecha_ini`` and
     ``:fecha_fin``. This function replaces those placeholders with Oracle
     ``TO_DATE`` expressions formatted as ``DD-MM-YYYY HH24:MI:SS``. If
     ``fecha_fin`` is not provided, the ``:fecha_fin`` placeholder is
-    replaced with ``SYSDATE``. When ``ne_id`` or ``action`` are provided,
-    respective ``AND`` clauses are appended using the ``:ne_id`` and
-    ``:action`` placeholders defined in ``sql/base_query.sql``.
+    replaced with ``SYSDATE``. When ``ne_id`` or a list of ``actions`` are
+    provided, respective ``AND`` clauses are appended using the ``:ne_id``
+    and ``:action`` placeholders defined in ``sql/base_query.sql``.
     """
 
     with open("sql/base_query.sql", "r", encoding="utf-8") as f:
@@ -43,10 +43,11 @@ def build_query(fecha_ini, fecha_fin=None, ne_id=None, action=None):
     else:
         query = query.replace(":ne_id", "")
 
-    if action:
+    if actions:
+        formatted_actions = "', '".join(actions)
         query = query.replace(
             ":action",
-            f"AND a.pri_action = '{action}'",
+            f"AND a.pri_action IN ('{formatted_actions}')",
         )
     else:
         query = query.replace(":action", "")


### PR DESCRIPTION
## Summary
- Switch action filter to `st.multiselect` with no default selection and pass list of selections to the query builder
- Update `build_query` to accept a list of actions and use `IN` when filtering

## Testing
- `python -m py_compile app.py data/query_builder.py`
- `pytest -q`
- manual query generation verifying absence/presence of action filter

------
https://chatgpt.com/codex/tasks/task_e_6894187a3d50832cbb649fcc75bf6eab