### PR TITLE
Reordenar filtros secuenciales

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,16 +64,19 @@ with col2:
     fecha_fin = datetime.datetime.combine(fecha_fin_fecha, fecha_fin_hora)
 with col3:
     ne_id = st.text_input("NE ID")
-    selected_actions = selected_services = None
+    selected_services = selected_actions = None
 
     if ne_id:
         if "db_conn" not in st.session_state:
             st.warning("🔌 No hay conexión activa")
             st.stop()
-        actions = get_actions(st.session_state["db_conn"], ne_id)
-        selected_actions = st.multiselect("Acción", actions)
         services = get_services(st.session_state["db_conn"], ne_id)
         selected_services = st.multiselect("Servicio", services)
+        if selected_services:
+            actions = get_actions(
+                st.session_state["db_conn"], ne_id, selected_services
+            )
+            selected_actions = st.multiselect("Acción", actions)
 
 
 # Ejecutar consulta

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -8,13 +8,17 @@ def get_transacciones(conn, query):
     return df
 
 
-def get_actions(conn, ne_id):
-    """Retrieve distinct actions available for a given NE ID."""
+def get_actions(conn, ne_id, services=None):
+    """Retrieve distinct actions for a given NE ID and optional services."""
     query = (
         "SELECT DISTINCT pri_action FROM swp_provisioning_interfaces "
         "WHERE pri_ne_id = :ne_id"
     )
-    df = pd.read_sql(query, conn, params={"ne_id": ne_id})
+    params = {"ne_id": ne_id}
+    if services:
+        formatted_services = "', '".join(services)
+        query += f" AND pri_ne_service IN ('{formatted_services}')"
+    df = pd.read_sql(query, conn, params=params)
     df.columns = df.columns.str.lower()
     return df["pri_action"].tolist()
 


### PR DESCRIPTION
## Summary
- Muestra NE ID como primer filtro y carga servicios disponibles
- Habilita selección de acciones basada en NE ID y servicios elegidos

## Testing
- `pytest`
- `python -m py_compile app.py services/data_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68942312b0bc832c8aa3f4586d4d27a8