### PR TITLE
feat: añadir gráfico de errores con detalle

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,11 @@ import streamlit as st
 from config.db_config import get_connection
 from data.query_builder import build_query
 from services.data_service import get_transacciones, get_actions, get_services
-from visualizations.charts import kpi_cards, status_pie_chart, error_bar_chart
+from visualizations.charts import (
+    kpi_cards,
+    status_pie_chart,
+    error_detail_bar_chart,
+)
 import datetime
 import pandas as pd
 
@@ -163,7 +167,7 @@ st.plotly_chart(status_pie_chart(df), use_container_width=True)
 # Gráfico de errores
 if not df[df['pri_status'] == 'E'].empty:
     st.subheader("📉 Códigos de Error")
-    st.plotly_chart(error_bar_chart(df), use_container_width=True)
+    st.plotly_chart(error_detail_bar_chart(df), use_container_width=True)
 
 if comparar:
     st.subheader("📊 Comparativo de transacciones")

--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -36,6 +36,11 @@ else:
         if error != "Todos":
             df_filtrado = df_filtrado[df_filtrado["pri_error_code"] == error]
 
+        mensajes = ["Todos"] + df_filtrado["pri_message_error"].dropna().unique().tolist()
+        mensaje = st.selectbox("Descripción del error", mensajes)
+        if mensaje != "Todos":
+            df_filtrado = df_filtrado[df_filtrado["pri_message_error"] == mensaje]
+
     if HAS_AGGRID:
         AgGrid(df_filtrado)
     else:

--- a/visualizations/charts.py
+++ b/visualizations/charts.py
@@ -47,3 +47,23 @@ def error_bar_chart(df):
     conteo.columns = ["Código Error", "Cantidad"]
     return px.bar(conteo, x="Código Error", y="Cantidad", title="Errores por Código", color="Cantidad")
 
+
+def error_detail_bar_chart(df):
+    if df.empty:
+        st.warning("No data available")
+        return px.Figure()
+    errores = df[df["pri_status"] == "E"]
+    conteo = (
+        errores.groupby(["pri_error_code", "pri_message_error"])
+        .size()
+        .reset_index(name="Cantidad")
+    )
+    conteo.columns = ["Código Error", "Descripción", "Cantidad"]
+    return px.bar(
+        conteo,
+        x="Código Error",
+        y="Cantidad",
+        color="Descripción",
+        title="Errores por Código y Descripción",
+    )
+


### PR DESCRIPTION
## Summary
- agregar `error_detail_bar_chart` que agrupa por código y descripción
- usar `error_detail_bar_chart` en lugar de `error_bar_chart`
- permitir filtrar también por descripción del error en el detalle

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895342fb7a4832c9eaab9fccfafe6dd