### PR TITLE
Normalize error messages for grouping

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from visualizations.charts import (
     status_pie_chart,
     error_detail_bar_chart,
 )
+from utils.helpers import normalize_error_message
 import datetime
 import pandas as pd
 
@@ -173,7 +174,10 @@ if comparar:
     st.subheader("📊 Comparativo de transacciones")
 
     def resumen(df_base):
-        errores = df_base[df_base["pri_status"] == "E"]
+        errores = df_base[df_base["pri_status"] == "E"].copy()
+        errores["pri_message_error"] = errores["pri_message_error"].apply(
+            normalize_error_message
+        )
         return (
             errores.groupby(["pri_error_code", "pri_message_error"])
             .size()

--- a/pages/detalle_transacciones.py
+++ b/pages/detalle_transacciones.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import datetime
+from utils.helpers import normalize_error_message
 
 try:
     from st_aggrid import AgGrid
@@ -28,14 +29,19 @@ else:
     estados = ["Todos"] + df["pri_status"].dropna().unique().tolist()
     estado = st.selectbox("Filtrar por estado", estados)
 
-    df_filtrado = df if estado == "Todos" else df[df["pri_status"] == estado]
+    df_filtrado = (
+        df if estado == "Todos" else df[df["pri_status"] == estado]
+    ).copy()
 
     if estado == "E":
         errores = ["Todos"] + df_filtrado["pri_error_code"].dropna().unique().tolist()
         error = st.selectbox("Tipo de error", errores)
         if error != "Todos":
-            df_filtrado = df_filtrado[df_filtrado["pri_error_code"] == error]
+            df_filtrado = df_filtrado[df_filtrado["pri_error_code"] == error].copy()
 
+        df_filtrado["pri_message_error"] = df_filtrado["pri_message_error"].apply(
+            normalize_error_message
+        )
         mensajes = ["Todos"] + df_filtrado["pri_message_error"].dropna().unique().tolist()
         mensaje = st.selectbox("Descripción del error", mensajes)
         if mensaje != "Todos":

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,1 +1,33 @@
-# Funciones auxiliares futuras
+"""Utility helpers for the dashboard project."""
+
+import re
+
+
+def normalize_error_message(message):
+    """Return a generic error message without variable identifiers.
+
+    Many error messages include dynamic information such as user IDs or
+    other numbers. To group errors effectively we strip any digits and
+    collapse extra whitespace so that messages differing only by those
+    identifiers map to the same generic text.
+
+    Parameters
+    ----------
+    message: str or any
+        Original error message. Non-string values are returned as-is.
+
+    Returns
+    -------
+    str or any
+        Normalized error message with digits removed and consecutive
+        whitespace collapsed. Non-string inputs are returned unchanged.
+    """
+
+    if not isinstance(message, str):
+        return message
+
+    # Remove any sequence of digits and collapse multiple spaces
+    normalized = re.sub(r"\d+", "", message)
+    normalized = " ".join(normalized.split())
+    return normalized
+

--- a/visualizations/charts.py
+++ b/visualizations/charts.py
@@ -1,5 +1,6 @@
 import streamlit as st
 import plotly.express as px
+from utils.helpers import normalize_error_message
 
 
 def kpi_cards(df):
@@ -52,7 +53,10 @@ def error_detail_bar_chart(df):
     if df.empty:
         st.warning("No data available")
         return px.Figure()
-    errores = df[df["pri_status"] == "E"]
+    errores = df[df["pri_status"] == "E"].copy()
+    errores["pri_message_error"] = errores["pri_message_error"].apply(
+        normalize_error_message
+    )
     conteo = (
         errores.groupby(["pri_error_code", "pri_message_error"])
         .size()


### PR DESCRIPTION
## Summary
- strip numeric identifiers from error messages for consistent grouping
- apply normalized messages in charts, summaries and detail filters

## Testing
- `python -m py_compile app.py visualizations/charts.py pages/detalle_transacciones.py utils/helpers.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689538557438832c91620d9751104f94