### PR TITLE
Remove status distribution charts and add error comparison

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,8 +4,7 @@ from data.query_builder import build_query
 from services.data_service import get_transacciones, get_actions, get_services
 from visualizations.charts import (
     kpi_cards,
-    status_pie_chart,
-    error_detail_bar_chart,
+    error_comparison_bar_chart,
 )
 from utils.helpers import normalize_error_message
 import datetime
@@ -162,14 +161,6 @@ kpi_cards(df)
 if st.button("Ver detalle de transacciones"):
     st.switch_page("pages/detalle_transacciones.py")
 
-# Pie chart
-st.plotly_chart(status_pie_chart(df), use_container_width=True)
-
-# Gráfico de errores
-if not df[df['pri_status'] == 'E'].empty:
-    st.subheader("📉 Códigos de Error")
-    st.plotly_chart(error_detail_bar_chart(df), use_container_width=True)
-
 if comparar:
     st.subheader("📊 Comparativo de transacciones")
 
@@ -201,3 +192,10 @@ if comparar:
             st.dataframe(resumen_cmp)
         else:
             st.write("Sin errores")
+
+    st.subheader("📈 Diferencia de errores")
+    st.plotly_chart(
+        error_comparison_bar_chart(resumen_actual, resumen_cmp),
+        use_container_width=True,
+    )
+


### PR DESCRIPTION
## Summary
- remove status and error distribution charts from dashboard
- add comparison bar chart highlighting error differences between periods

## Testing
- `python -m py_compile app.py visualizations/charts.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895506c3c0c832c8137dd8a18f17243