### PR TITLE
Add link button for transaction detail page

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,8 +177,12 @@ st.plotly_chart(
     use_container_width=True,
 )
 
-if st.button("Ver detalle de transacciones"):
-    st.switch_page("pages/detalle_transacciones.py")
+st.markdown(
+    "<a href='/detalle_transacciones' target='_blank'>"
+    "<button>Ver detalle de transacciones</button>"
+    "</a>",
+    unsafe_allow_html=True,
+)
 
 if comparar:
     st.subheader("📊 Comparativo de transacciones")


### PR DESCRIPTION
## Summary
- replace page switch button with link opening transaction detail page in a new tab

## Testing
- `python -m py_compile app.py pages/detalle_transacciones.py`


------
https://chatgpt.com/codex/tasks/task_e_689930ac8848832cafc7b2671630d50e