### PR TITLE
feat: add real-time operations shortcut

### DIFF
--- a/app.py
+++ b/app.py
@@ -122,6 +122,13 @@ if comparar:
 else:
     fecha_ini_cmp = fecha_fin_cmp = None
 
+st.markdown(
+    "<a href='/operaciones_tiempo_real' target='_blank'>"
+    "<button>Ver operaciones en tiempo real</button>"
+    "</a>",
+    unsafe_allow_html=True,
+)
+
 # Ejecutar consulta
 if "db_conn" not in st.session_state:
     st.warning("🔌 No hay conexión activa")
@@ -170,13 +177,6 @@ if comparar:
 
 # KPIs
 kpi_cards(df)
-
-st.markdown(
-    "<a href='/operaciones_tiempo_real' target='_blank'>",
-    "<button>Ver operaciones en tiempo real</button>",
-    "</a>",
-    unsafe_allow_html=True,
-)
 
 st.markdown(
     "<a href='/detalle_transacciones' target='_blank'>",


### PR DESCRIPTION
## Summary
- add a button below the filter section to open the real-time operations page
- keep KPI area focused on transaction details by removing the duplicate button

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a058d5cfc832ca634e2820c1d1fdc