### PR TITLE
Normaliza texto en generar_insert y añade pruebas unitarias

### DIFF
--- a/tests/test_sql_utils.py
+++ b/tests/test_sql_utils.py
@@ -1,0 +1,44 @@
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.sql_utils import generar_insert
+
+
+def test_fecha_datetime():
+    fila = {"fecha": datetime.datetime(2025, 4, 29, 0, 15, 31)}
+    sql = generar_insert("mi_tabla", fila)
+    assert "TO_DATE('29-04-2025 00:15:31', 'DD-MM-YYYY HH24:MI:SS')" in sql
+
+
+def test_none_value():
+    fila = {"valor": None}
+    sql = generar_insert("mi_tabla", fila)
+    assert "NULL" in sql
+
+
+def test_numeric_values():
+    fila = {"id": 123, "monto": 45.67}
+    sql = generar_insert("mi_tabla", fila)
+    assert "123" in sql and "45.67" in sql
+
+
+def test_text_with_quotes():
+    fila = {"nombre": "O'Hara"}
+    sql = generar_insert("mi_tabla", fila)
+    assert "'O''Hara'" in sql
+
+
+def test_multiline_text():
+    fila = {"xml": "<Request>\n<accion>Test</accion>\n</Request>"}
+    sql = generar_insert("mi_tabla", fila)
+    assert "\n" not in sql
+    assert "<Request>" in sql and "</Request>" in sql
+
+
+def test_string_date():
+    fila = {"fecha": "2025-04-29 10:27:18"}
+    sql = generar_insert("mi_tabla", fila)
+    assert "TO_DATE('29-04-2025 10:27:18', 'DD-MM-YYYY HH24:MI:SS')" in sql

--- a/utils/sql_utils.py
+++ b/utils/sql_utils.py
@@ -3,7 +3,7 @@
 import re
 from datetime import date, datetime
 from numbers import Real
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import pandas as pd
 
@@ -32,19 +32,20 @@ def _format_sql_value(value: Any) -> str:
         return _to_oracle_to_date(pd.to_datetime(value))
 
     if isinstance(value, str):
-        stripped = value.strip()
-        if stripped.upper().startswith("TO_DATE("):
-            return stripped
+        s = value.replace("\n", " ").replace("\r", " ").replace("\t", " ")
+        s = re.sub(r"\s+", " ", s).strip()
+        if s.upper().startswith("TO_DATE("):
+            return s
 
-        if re.match(r"^\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?$", stripped):
+        if re.match(r"^\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2})?$", s):
             try:
-                parsed = pd.to_datetime(stripped)
+                parsed = pd.to_datetime(s)
             except ValueError:
                 pass
             else:
                 return _to_oracle_to_date(parsed)
 
-        return "'" + stripped.replace("'", "''") + "'"
+        return "'" + s.replace("'", "''") + "'"
 
     if isinstance(value, Real):
         if isinstance(value, float) and value.is_integer():
@@ -54,8 +55,22 @@ def _format_sql_value(value: Any) -> str:
     return "'" + str(value).replace("'", "''") + "'"
 
 
-def generar_insert(row: Dict[str, Any], tabla: str = "swp_provisioning_interfaces") -> str:
-    """Build an ``INSERT`` statement for ``tabla`` from ``row`` data."""
+def generar_insert(
+    tabla_or_row: Union[str, Dict[str, Any]],
+    row: Dict[str, Any] | None = None,
+) -> str:
+    """Build an ``INSERT`` statement.
+
+    Call ``generar_insert(row)`` to use the default table
+    ``swp_provisioning_interfaces`` or ``generar_insert(tabla, row)`` to
+    specify a custom table name.
+    """
+
+    if row is None:
+        row = tabla_or_row  # type: ignore[assignment]
+        tabla = "swp_provisioning_interfaces"
+    else:
+        tabla = tabla_or_row  # type: ignore[assignment]
 
     columnas = ", ".join(row.keys())
     valores = []
@@ -65,8 +80,6 @@ def generar_insert(row: Dict[str, Any], tabla: str = "swp_provisioning_interface
                 f"(SELECT NVL(MAX(pri_id), 0) + 1 FROM {tabla})"
             )
         else:
-            if col.lower() == "pri_request" and isinstance(valor, str):
-                valor = valor.replace("\n", "").replace("\r", "")
             valores.append(_format_sql_value(valor))
 
     return f"INSERT INTO {tabla} ({columnas}) VALUES ({', '.join(valores)});"


### PR DESCRIPTION
## Summary
- Limpia saltos y tabulaciones en valores de texto antes de generar el SQL
- Permite invocar `generar_insert` con o sin tabla explícita
- Agrega tests unitarios para fechas, nulos, numéricos y textos

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b204e6e9f0832cac01b424352fccb7