### PR TITLE
Migrate to FastAPI + React with pagination and CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__
+*.pyc
+node_modules
+.env
+.git
+.gitignore

--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ JWT_SECRET=change_me
 JWT_EXPIRES_MIN=60
 LOG_FILE_PATH=/var/log/app/app.log
 VITE_API_BASE=/api
+ALLOW_ORIGINS=*

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/api"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,0 +1,18 @@
+name: API
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r api/requirements.txt pytest
+      - run: ruff api
+      - run: black --check api
+      - run: isort --check-only api
+      - run: mypy api
+      - run: pytest -q api

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,16 @@
+name: Web
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: cd web && npm ci
+      - run: cd web && npm run lint
+      - run: cd web && npm test
+      - run: cd web && npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /.idea/workspace.xml
 __pycache__/
 *.pyc
+node_modules/
+.env
+web/dist/
+web/package-lock.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        files: ^api/
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        files: ^api/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.272
+    hooks:
+      - id: ruff
+        files: ^api/
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+      - id: mypy
+        files: ^api/
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v8.56.0
+    hooks:
+      - id: eslint
+        files: ^web/
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0
+    hooks:
+      - id: prettier
+        files: ^web/

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Proyecto migrado a arquitectura de dos capas con **FastAPI** y **React**.
   npm run dev
   ```
 
+### Variables de entorno
+Ver `.env.example` para configurar conexión Oracle, JWT y rutas.
+
+### Rutas API
+- `GET /healthz`
+- `GET /provisioning/interfaces?page=1&page_size=50`
+
+Ejemplo:
+
+```bash
+curl -H "Authorization: Bearer <token>" "http://localhost:8000/provisioning/interfaces?page=1&page_size=10"
+```
+
 ## Tests
 - Python: `pytest -q`
 - Frontend: `npm test`

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+
 from pydantic_settings import BaseSettings
 
 
@@ -11,6 +12,7 @@ class Settings(BaseSettings):
     JWT_SECRET: str = "change_me"
     JWT_EXPIRES_MIN: int = 60
     LOG_FILE_PATH: str = "/var/log/app/app.log"
+    ALLOW_ORIGINS: str = "*"
 
     class Config:
         env_file = ".env"

--- a/api/app/core/deps.py
+++ b/api/app/core/deps.py
@@ -1,10 +1,12 @@
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Header, HTTPException, status
 
 from .security import decode_token
 
 
 def get_current_user(authorization: str = Header("")) -> str:
     if not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing token"
+        )
     token = authorization.split(" ", 1)[1]
     return decode_token(token)

--- a/api/app/core/security.py
+++ b/api/app/core/security.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timedelta
 from typing import Optional
 
+import jwt
 from fastapi import HTTPException, status
-from jose import JWTError, jwt
+from jwt import PyJWTError
 from passlib.context import CryptContext
 
 from .config import get_settings
@@ -12,7 +13,9 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 def create_access_token(subject: str, expires_minutes: Optional[int] = None) -> str:
     settings = get_settings()
-    expire = datetime.utcnow() + timedelta(minutes=expires_minutes or settings.JWT_EXPIRES_MIN)
+    expire = datetime.utcnow() + timedelta(
+        minutes=expires_minutes or settings.JWT_EXPIRES_MIN
+    )
     to_encode = {"sub": subject, "exp": expire}
     return jwt.encode(to_encode, settings.JWT_SECRET, algorithm="HS256")
 
@@ -30,5 +33,7 @@ def decode_token(token: str) -> str:
     try:
         payload = jwt.decode(token, settings.JWT_SECRET, algorithms=["HS256"])
         return payload.get("sub", "")
-    except JWTError:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    except PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        )

--- a/api/app/db/queries.py
+++ b/api/app/db/queries.py
@@ -1,19 +1,63 @@
-LIST_PROVISIONING = """
-SELECT * FROM provisioning_interface
-WHERE 1=1
-    {msisdn_filter}
-    {status_filter}
-    {error_filter}
-    {ne_service_filter}
-    {date_filter}
-ORDER BY {order_column} {order_dir}
-"""
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 
-DETAIL_PROVISIONING = "SELECT * FROM provisioning_interface WHERE pri_id = :pri_id"
+from .oracle import fetch_all, fetch_one
 
-STATS_PROVISIONING = """
-SELECT {group_by} as group_key, COUNT(*) as total
-FROM provisioning_interface
-WHERE pri_action_date BETWEEN :from AND :to
-GROUP BY {group_by}
-"""
+
+def list_interfaces(
+    filters: Dict[str, Any],
+    sort_by: str,
+    sort_dir: str,
+    limit: int,
+    offset: int,
+) -> Dict[str, Any]:
+    where = ["1=1"]
+    params: Dict[str, Any] = {}
+    if msisdn := filters.get("msisdn"):
+        where.append("pri_cellular_number = :msisdn")
+        params["msisdn"] = msisdn
+    if status := filters.get("status"):
+        where.append("pri_status = :status")
+        params["status"] = status
+    if error_code := filters.get("error_code"):
+        where.append("pri_error_code = :error_code")
+        params["error_code"] = error_code
+    if ne_service := filters.get("ne_service"):
+        where.append("pri_ne_service = :ne_service")
+        params["ne_service"] = ne_service
+    if date_from := filters.get("from"):
+        where.append("pri_action_date >= :date_from")
+        params["date_from"] = date_from
+    if date_to := filters.get("to"):
+        where.append("pri_action_date <= :date_to")
+        params["date_to"] = date_to
+
+    base = " FROM provisioning_interface WHERE " + " AND ".join(where)
+    total = fetch_one("SELECT COUNT(*) as cnt" + base, params) or {"cnt": 0}
+    rows = fetch_all(
+        f"SELECT *{base} ORDER BY {sort_by} {sort_dir}",
+        params,
+        limit=limit,
+        offset=offset,
+    )
+    return {"total_count": total["cnt"], "rows": rows}
+
+
+def get_interface(pri_id: int) -> Optional[Dict[str, Any]]:
+    return fetch_one(
+        "SELECT * FROM provisioning_interface WHERE pri_id = :pri_id",
+        {"pri_id": pri_id},
+    )
+
+
+def stats(
+    group_by: str, date_from: datetime, date_to: datetime
+) -> List[Dict[str, Any]]:
+    query = (
+        f"SELECT pri_{group_by} as group_key, COUNT(*) as total "
+        "FROM provisioning_interface "
+        "WHERE pri_action_date BETWEEN :date_from AND :date_to "
+        f"GROUP BY pri_{group_by}"
+    )
+    params = {"date_from": date_from, "date_to": date_to}
+    return fetch_all(query, params)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,22 +1,37 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .core.config import get_settings
 from .routers import auth, provisioning, stream
 
+settings = get_settings()
 app = FastAPI(title="Provisioning API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=[origin.strip() for origin in settings.ALLOW_ORIGINS.split(",")],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
 
+metrics_counter = {"requests": 0}
+
 
 @app.get("/healthz")
 def healthz():
     return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics():
+    return metrics_counter
+
+
+@app.middleware("http")
+async def add_metrics(request, call_next):
+    metrics_counter["requests"] += 1
+    return await call_next(request)
 
 
 app.include_router(auth.router)

--- a/api/app/models/provisioning.py
+++ b/api/app/models/provisioning.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from typing import List
+
 from pydantic import BaseModel
 
 
-class Provisioning(BaseModel):
+class InterfaceRow(BaseModel):
     pri_id: int
     pri_cellular_number: str
     pri_status: str
@@ -12,10 +14,11 @@ class Provisioning(BaseModel):
     pri_ne_service: str | None = None
 
 
-class ProvisioningFilter(BaseModel):
-    msisdn: str | None = None
-    status: str | None = None
-    error_code: str | None = None
-    ne_service: str | None = None
-    date_from: datetime | None = None
-    date_to: datetime | None = None
+class InterfacesResponse(BaseModel):
+    total_count: int
+    rows: List[InterfaceRow]
+
+
+class StatsItem(BaseModel):
+    group_key: str | None = None
+    total: int

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel
 
-from ..core.security import create_access_token, verify_password, get_password_hash
+from ..core.security import (create_access_token, get_password_hash,
+                             verify_password)
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -11,10 +12,19 @@ class LoginRequest(BaseModel):
     password: str
 
 
+DEMO_USER = "admin"
+DEMO_HASH = get_password_hash("admin")
+
+
 @router.post("/login")
 def login(data: LoginRequest):
-    # Dummy user validation
-    if data.username != "admin" or data.password != "admin":
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    if len(data.username) < 3 or len(data.password) < 3:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="invalid input"
+        )
+    if data.username != DEMO_USER or not verify_password(data.password, DEMO_HASH):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials"
+        )
     token = create_access_token(data.username)
     return {"access_token": token, "token_type": "bearer"}

--- a/api/app/routers/provisioning.py
+++ b/api/app/routers/provisioning.py
@@ -1,64 +1,55 @@
+from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 
 from ..core.deps import get_current_user
-from ..db import oracle, queries
+from ..db import queries
+from ..models.provisioning import InterfaceRow, InterfacesResponse, StatsItem
 
 router = APIRouter(prefix="/provisioning", tags=["provisioning"])
 
 
-@router.get("/interfaces")
+@router.get("/interfaces", response_model=InterfacesResponse)
 def list_interfaces(
     page: int = 1,
-    page_size: int = 10,
-    sort: str = "pri_id",
-    msisdn: Optional[str] = None,
-    status: Optional[str] = None,
-    error_code: Optional[str] = None,
-    ne_service: Optional[str] = None,
+    page_size: int = 50,
+    sort_by: str = "pri_action_date",
+    sort_dir: str = "desc",
+    msisdn: str | None = None,
+    status: str | None = None,
+    error_code: str | None = None,
+    ne_service: str | None = None,
+    date_from: Optional[datetime] = Query(None, alias="from"),
+    date_to: Optional[datetime] = Query(None, alias="to"),
     user: str = Depends(get_current_user),
-):
-    filters = []
-    params: dict[str, object] = {}
-    if msisdn:
-        filters.append("AND pri_cellular_number = :msisdn")
-        params["msisdn"] = msisdn
-    if status:
-        filters.append("AND pri_status = :status")
-        params["status"] = status
-    if error_code:
-        filters.append("AND pri_error_code = :error_code")
-        params["error_code"] = error_code
-    if ne_service:
-        filters.append("AND pri_ne_service = :ne_service")
-        params["ne_service"] = ne_service
-    query = queries.LIST_PROVISIONING.format(
-        msisdn_filter=" ".join(f for f in filters if 'msisdn' in f),
-        status_filter=" ".join(f for f in filters if 'status' in f),
-        error_filter=" ".join(f for f in filters if 'error_code' in f),
-        ne_service_filter=" ".join(f for f in filters if 'ne_service' in f),
-        date_filter="",
-        order_column=sort,
-        order_dir="ASC",
-    )
+) -> InterfacesResponse:
+    filters = {
+        "msisdn": msisdn,
+        "status": status,
+        "error_code": error_code,
+        "ne_service": ne_service,
+        "from": date_from,
+        "to": date_to,
+    }
     offset = (page - 1) * page_size
-    data = oracle.fetch_page(query, params, limit=page_size, offset=offset)
-    return {"data": data}
+    result = queries.list_interfaces(filters, sort_by, sort_dir, page_size, offset)
+    rows = [InterfaceRow(**row) for row in result["rows"]]
+    return InterfacesResponse(total_count=result["total_count"], rows=rows)
 
 
-@router.get("/interfaces/{pri_id}")
+@router.get("/interfaces/{pri_id}", response_model=InterfaceRow | None)
 def get_interface(pri_id: int, user: str = Depends(get_current_user)):
-    return oracle.fetch_one(queries.DETAIL_PROVISIONING, {"pri_id": pri_id})
+    row = queries.get_interface(pri_id)
+    return InterfaceRow(**row) if row else None
 
 
-@router.get("/interfaces/stats")
+@router.get("/interfaces/stats", response_model=list[StatsItem])
 def get_stats(
-    group_by: str = Query("status", regex="^(status|error_code|ne_service)$"),
-    _from: str = Query(..., alias="from"),
-    to: str = Query(...),
+    group_by: str = Query("status", pattern="^(status|error_code|ne_service)$"),
+    date_from: datetime = Query(..., alias="from"),
+    date_to: datetime = Query(..., alias="to"),
     user: str = Depends(get_current_user),
-):
-    query = queries.STATS_PROVISIONING.format(group_by=f"pri_{group_by}")
-    params = {"from": _from, "to": to}
-    return oracle.fetch_all(query, params)
+) -> list[StatsItem]:
+    rows = queries.stats(group_by, date_from, date_to)
+    return [StatsItem(**row) for row in rows]

--- a/api/app/routers/stream.py
+++ b/api/app/routers/stream.py
@@ -16,11 +16,14 @@ async def stream_logs(ws: WebSocket):
     if not path.exists():
         await ws.close(code=1000)
         return
-    with path.open("r") as f:
-        f.seek(0, 2)
-        while True:
-            line = f.readline()
-            if line:
-                await ws.send_text(line.rstrip())
-            else:
-                await asyncio.sleep(0.5)
+    last_size = 0
+    while True:
+        try:
+            with path.open("r") as f:
+                f.seek(last_size)
+                for line in f:
+                    await ws.send_text(line.rstrip())
+                last_size = f.tell()
+        except FileNotFoundError:  # rotated
+            last_size = 0
+        await asyncio.sleep(0.5)

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,6 +1,7 @@
 fastapi
 uvicorn[standard]
 pydantic
+pydantic-settings
 python-dotenv
 cx_Oracle
 oracledb

--- a/api/tests/test_provisioning.py
+++ b/api/tests/test_provisioning.py
@@ -3,22 +3,39 @@ from fastapi.testclient import TestClient
 from app.main import app
 
 
-class DummyUser:
-    token = "token"
-
-
 def auth_header():
     return {"Authorization": "Bearer dummy"}
 
 
 def test_list_interfaces(monkeypatch):
-    def fake_fetch_page(query, params, limit, offset):
-        return [{"pri_id": 1, "pri_cellular_number": "123", "pri_status": "OK"}]
+    captured = {}
 
-    monkeypatch.setattr("app.db.oracle.fetch_page", fake_fetch_page)
+    def fake_fetch_all(query, params, limit=None, offset=None):
+        captured.update({"params": params, "limit": limit, "offset": offset})
+        return [
+            {
+                "pri_id": 1,
+                "pri_cellular_number": "123",
+                "pri_status": "OK",
+                "pri_action_date": "2020-01-01T00:00:00",
+            }
+        ]
+
+    def fake_fetch_one(query, params=None):
+        return {"cnt": 1}
+
+    monkeypatch.setattr("app.db.queries.fetch_all", fake_fetch_all)
+    monkeypatch.setattr("app.db.queries.fetch_one", fake_fetch_one)
     monkeypatch.setattr("app.core.deps.decode_token", lambda token: "user")
 
     client = TestClient(app)
-    resp = client.get("/provisioning/interfaces", headers=auth_header())
+    resp = client.get(
+        "/provisioning/interfaces?page=2&page_size=10&status=OK",
+        headers=auth_header(),
+    )
     assert resp.status_code == 200
-    assert resp.json()["data"][0]["pri_id"] == 1
+    body = resp.json()
+    assert body["total_count"] == 1
+    assert captured["limit"] == 10
+    assert captured["offset"] == 10
+    assert captured["params"]["status"] == "OK"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,23 @@ services:
     env_file: .env
     ports:
       - "8000:8000"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   web:
     build: ./web
     env_file: .env
     ports:
       - "5173:5173"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5173"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
   proxy:
     image: nginx:alpine
     volumes:
@@ -19,3 +31,4 @@ services:
     depends_on:
       - api
       - web
+    restart: unless-stopped

--- a/web/.eslintrc.cjs
+++ b/web/.eslintrc.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  root: true,
+  env: { browser: true, es2021: true },
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  parserOptions: { ecmaFeatures: { jsx: true }, ecmaVersion: 'latest', sourceType: 'module' },
+  settings: { }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -28,6 +28,7 @@
     "autoprefixer": "^10.4.0",
     "eslint": "^8.0.0",
     "postcss": "^8.4.0",
+    "@vitejs/plugin-react": "^4.2.0",
     "typescript": "^5.0.0",
     "vite": "^5.0.0",
     "vitest": "^1.0.0"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,8 @@
-import { Link, Route, Routes } from 'react-router-dom'
+import { Link, Route, Routes, Navigate } from 'react-router-dom'
 import Dashboard from './pages/Dashboard'
 import Interfaces from './pages/Interfaces'
 import Logs from './pages/Logs'
+import Login from './pages/Login'
 
 export default function App() {
   return (
@@ -12,10 +13,24 @@ export default function App() {
         <Link to="/logs">Logs</Link>
       </nav>
       <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/interfaces" element={<Interfaces />} />
-        <Route path="/logs" element={<Logs />} />
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/*"
+          element={
+            localStorage.getItem('token') ? <ProtectedRoutes /> : <Navigate to="/login" replace />
+          }
+        />
       </Routes>
     </div>
+  )
+}
+
+function ProtectedRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Dashboard />} />
+      <Route path="/interfaces" element={<Interfaces />} />
+      <Route path="/logs" element={<Logs />} />
+    </Routes>
   )
 }

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -1,8 +1,7 @@
-import { useEffect } from 'react'
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 
 interface DataTableProps<T> {
-  columns: ColumnDef<T, any>[]
+  columns: ColumnDef<T, unknown>[]
   data: T[]
 }
 

--- a/web/src/components/FiltersBar.tsx
+++ b/web/src/components/FiltersBar.tsx
@@ -6,17 +6,18 @@ interface Props {
 
 export default function FiltersBar({ onChange }: Props) {
   const [msisdn, setMsisdn] = useState('')
+  const [status, setStatus] = useState('')
+  const [error, setError] = useState('')
+  const [neService, setNeService] = useState('')
 
   return (
-    <div className="flex space-x-2 mb-4">
-      <input
-        value={msisdn}
-        onChange={e => setMsisdn(e.target.value)}
-        placeholder="MSISDN"
-        className="border p-2"
-      />
+    <div className="flex flex-wrap gap-2 mb-4">
+      <input className="border p-2" value={msisdn} onChange={e => setMsisdn(e.target.value)} placeholder="MSISDN" />
+      <input className="border p-2" value={status} onChange={e => setStatus(e.target.value)} placeholder="Status" />
+      <input className="border p-2" value={error} onChange={e => setError(e.target.value)} placeholder="Error" />
+      <input className="border p-2" value={neService} onChange={e => setNeService(e.target.value)} placeholder="NE Service" />
       <button
-        onClick={() => onChange({ msisdn })}
+        onClick={() => onChange({ msisdn, status, error_code: error, ne_service: neService })}
         className="bg-blue-600 text-white px-4"
       >
         Buscar

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest'
+import api from './api'
+
+describe('api', () => {
+  it('has base url', () => {
+    expect(api.defaults.baseURL).toBe('/api')
+  })
+})

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,4 +13,15 @@ api.interceptors.request.use(config => {
   return config
 })
 
+api.interceptors.response.use(
+  resp => resp,
+  error => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem('token')
+      window.location.href = '/login'
+    }
+    return Promise.reject(error)
+  }
+)
+
 export default api

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 import './index.css'
 
+const qc = new QueryClient()
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={qc}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>
 )

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,19 +1,32 @@
 import { useQuery } from '@tanstack/react-query'
 import api from '../lib/api'
 import StatsCards from '../components/StatsCards'
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts'
 
 export default function Dashboard() {
   const { data } = useQuery({
     queryKey: ['stats'],
-    queryFn: () => api.get('/provisioning/interfaces/stats', { params: { group_by: 'status', from: '2020-01-01', to: '2030-01-01' } }).then(r => r.data)
+    queryFn: () =>
+      api
+        .get('/provisioning/interfaces/stats', {
+          params: { group_by: 'status', from: '2020-01-01', to: '2030-01-01' },
+        })
+        .then(r => r.data),
   })
 
-  const stats = (data || []).map((s: any) => ({ label: s.group_key, value: s.total }))
+  const stats = (data || []).map((s: { group_key: string; total: number }) => ({ label: s.group_key, value: s.total }))
 
   return (
     <div>
       <h1 className="text-xl mb-4">Dashboard</h1>
       <StatsCards stats={stats} />
+      <ResponsiveContainer width="100%" height={200}>
+        <BarChart data={stats}>
+          <XAxis dataKey="label" />
+          <YAxis />
+          <Bar dataKey="value" fill="#3182ce" />
+        </BarChart>
+      </ResponsiveContainer>
     </div>
   )
 }

--- a/web/src/pages/Interfaces.tsx
+++ b/web/src/pages/Interfaces.tsx
@@ -4,30 +4,44 @@ import api from '../lib/api'
 import DataTable from '../components/DataTable'
 import FiltersBar from '../components/FiltersBar'
 
-interface Row {
-  pri_id: number
-  pri_cellular_number: string
-  pri_status: string
-}
-
 export default function Interfaces() {
   const [filters, setFilters] = useState<Record<string, string>>({})
+  const [page, setPage] = useState(1)
+  const pageSize = 10
+
   const { data } = useQuery({
-    queryKey: ['interfaces', filters],
-    queryFn: () => api.get('/provisioning/interfaces', { params: { ...filters } }).then(r => r.data.data)
+    queryKey: ['interfaces', filters, page],
+    queryFn: () =>
+      api
+        .get('/provisioning/interfaces', {
+          params: { page, page_size: pageSize, sort_by: 'pri_id', sort_dir: 'asc', ...filters },
+        })
+        .then(r => r.data),
   })
 
   const columns = [
     { header: 'ID', accessorKey: 'pri_id' },
     { header: 'MSISDN', accessorKey: 'pri_cellular_number' },
-    { header: 'Status', accessorKey: 'pri_status' }
+    { header: 'Status', accessorKey: 'pri_status' },
   ]
 
   return (
     <div>
       <h1 className="text-xl mb-4">Interfaces</h1>
-      <FiltersBar onChange={setFilters} />
-      <DataTable columns={columns} data={data || []} />
+      <FiltersBar onChange={f => { setFilters(f); setPage(1) }} />
+      <DataTable columns={columns} data={data?.rows || []} />
+      <div className="mt-2 space-x-2">
+        <button disabled={page === 1} onClick={() => setPage(p => p - 1)} className="px-2 border">
+          Prev
+        </button>
+        <button
+          disabled={(data?.rows.length || 0) < pageSize}
+          onClick={() => setPage(p => p + 1)}
+          className="px-2 border"
+        >
+          Next
+        </button>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+import api from '../lib/api'
+
+export default function Login() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const submit = async () => {
+    const { data } = await api.post('/auth/login', { username, password })
+    localStorage.setItem('token', data.access_token)
+    window.location.href = '/'
+  }
+
+  return (
+    <div className="p-4 max-w-sm mx-auto space-y-2">
+      <input
+        className="border p-2 w-full"
+        placeholder="Usuario"
+        value={username}
+        onChange={e => setUsername(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full"
+        placeholder="Clave"
+        type="password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <button className="bg-blue-600 text-white px-4" onClick={submit}>
+        Login
+      </button>
+    </div>
+  )
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   server: {
     port: 5173,
+    proxy: {
+      '/api': 'http://localhost:8000',
+    },
   },
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- implement FastAPI backend with Oracle helpers, JWT auth and log streaming
- add React TS frontend with server-side pagination and login
- setup Docker, Nginx proxy, pre-commit and GitHub Actions

## Testing
- `ruff check api/app api/tests`
- `black --check api/app api/tests`
- `isort --check-only api/app api/tests`
- `mypy --ignore-missing-imports api/app`
- `PYTHONPATH=api pytest -q api/tests`
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6d8b0b7ac832c87ced766c2fb5c55