### PR TITLE
feat: interactive env setup for Oracle credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,3 @@ JWT_SECRET=change_me
 JWT_EXPIRES_MIN=60
 LOG_FILE_PATH=/var/log/app/app.log
 VITE_API_BASE=/api
-ALLOW_ORIGINS=*

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ __pycache__/
 *.pyc
 node_modules/
 .env
+.env.local
+*.bak
 web/dist/
 web/package-lock.json

--- a/README.md
+++ b/README.md
@@ -5,14 +5,33 @@ Proyecto migrado a arquitectura de dos capas con **FastAPI** y **React**.
 ## Requisitos
 - Docker y docker-compose
 
-## Ejecución
+## Configuración de entorno
 
-1. Copiar `.env.example` a `.env` y ajustar variables.
-2. Construir y ejecutar contenedores:
+1. Generar `.env` desde el ejemplo (opcional):
+   ```bash
+   cp .env.example .env
+   ```
+   o ejecutar el asistente interactivo:
+
+   **Windows**
+   ```bash
+   py scripts/configure_env.py
+   ```
+
+   **Linux/Mac**
+   ```bash
+   python3 scripts/configure_env.py
+   ```
+
+2. Levantar contenedores:
    ```bash
    docker compose up --build
    ```
-3. Navegar a [http://localhost](http://localhost).
+
+3. Verificar servicios:
+   - Front: [http://localhost](http://localhost)
+   - Health: [http://localhost/api/healthz](http://localhost/api/healthz)
+   - Docs API: [http://localhost/api/docs](http://localhost/api/docs)
 
 ## Estructura
 - `api/` – Backend FastAPI con conexión Oracle y WebSockets.

--- a/api/app/core/config.py
+++ b/api/app/core/config.py
@@ -1,23 +1,16 @@
-from functools import lru_cache
+import os
 
-from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
 
+load_dotenv()  # carga .env desde la raíz del repo
 
-class Settings(BaseSettings):
-    ORACLE_DSN: str = ""
-    ORACLE_USER: str = ""
-    ORACLE_PASSWORD: str = ""
-    ORACLE_POOL_MIN: int = 1
-    ORACLE_POOL_MAX: int = 5
-    JWT_SECRET: str = "change_me"
-    JWT_EXPIRES_MIN: int = 60
-    LOG_FILE_PATH: str = "/var/log/app/app.log"
-    ALLOW_ORIGINS: str = "*"
-
-    class Config:
-        env_file = ".env"
-
-
-@lru_cache()
-def get_settings() -> Settings:
-    return Settings()
+ORACLE_DSN = os.getenv("ORACLE_DSN", "")
+ORACLE_USER = os.getenv("ORACLE_USER", "")
+ORACLE_PASSWORD = os.getenv("ORACLE_PASSWORD", "")
+ORACLE_POOL_MIN = int(os.getenv("ORACLE_POOL_MIN", "1"))
+ORACLE_POOL_MAX = int(os.getenv("ORACLE_POOL_MAX", "5"))
+JWT_SECRET = os.getenv("JWT_SECRET", "change_me")
+JWT_EXPIRES_MIN = int(os.getenv("JWT_EXPIRES_MIN", "60"))
+LOG_FILE_PATH = os.getenv("LOG_FILE_PATH", "/var/log/app/app.log")
+ALLOW_ORIGINS = os.getenv("ALLOW_ORIGINS", "*")
+VITE_API_BASE = os.getenv("VITE_API_BASE", "/api")

--- a/api/app/core/security.py
+++ b/api/app/core/security.py
@@ -6,18 +6,17 @@ from fastapi import HTTPException, status
 from jwt import PyJWTError
 from passlib.context import CryptContext
 
-from .config import get_settings
+from . import config
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def create_access_token(subject: str, expires_minutes: Optional[int] = None) -> str:
-    settings = get_settings()
     expire = datetime.utcnow() + timedelta(
-        minutes=expires_minutes or settings.JWT_EXPIRES_MIN
+        minutes=expires_minutes or config.JWT_EXPIRES_MIN
     )
     to_encode = {"sub": subject, "exp": expire}
-    return jwt.encode(to_encode, settings.JWT_SECRET, algorithm="HS256")
+    return jwt.encode(to_encode, config.JWT_SECRET, algorithm="HS256")
 
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
@@ -29,9 +28,8 @@ def get_password_hash(password: str) -> str:
 
 
 def decode_token(token: str) -> str:
-    settings = get_settings()
     try:
-        payload = jwt.decode(token, settings.JWT_SECRET, algorithms=["HS256"])
+        payload = jwt.decode(token, config.JWT_SECRET, algorithms=["HS256"])
         return payload.get("sub", "")
     except PyJWTError:
         raise HTTPException(

--- a/api/app/db/oracle.py
+++ b/api/app/db/oracle.py
@@ -5,17 +5,15 @@ try:
 except Exception:  # pragma: no cover
     import cx_Oracle  # type: ignore
 
-from ..core.config import get_settings
-
-settings = get_settings()
+from ..core import config
 
 try:  # pragma: no cover - no client in tests
     pool: cx_Oracle.SessionPool | None = cx_Oracle.SessionPool(
-        user=settings.ORACLE_USER,
-        password=settings.ORACLE_PASSWORD,
-        dsn=settings.ORACLE_DSN,
-        min=settings.ORACLE_POOL_MIN,
-        max=settings.ORACLE_POOL_MAX,
+        user=config.ORACLE_USER,
+        password=config.ORACLE_PASSWORD,
+        dsn=config.ORACLE_DSN,
+        min=config.ORACLE_POOL_MIN,
+        max=config.ORACLE_POOL_MAX,
         increment=1,
         threaded=True,
         getmode=cx_Oracle.SPOOL_ATTRVAL_WAIT,

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -1,15 +1,14 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .core.config import get_settings
+from .core import config
 from .routers import auth, provisioning, stream
 
-settings = get_settings()
 app = FastAPI(title="Provisioning API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[origin.strip() for origin in settings.ALLOW_ORIGINS.split(",")],
+    allow_origins=[origin.strip() for origin in config.ALLOW_ORIGINS.split(",")],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/api/app/routers/stream.py
+++ b/api/app/routers/stream.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from fastapi import APIRouter, WebSocket
 
-from ..core.config import get_settings
+from ..core import config
 
 router = APIRouter(prefix="/logs", tags=["logs"])
 
@@ -11,8 +11,7 @@ router = APIRouter(prefix="/logs", tags=["logs"])
 @router.websocket("/stream")
 async def stream_logs(ws: WebSocket):
     await ws.accept()
-    settings = get_settings()
-    path = Path(settings.LOG_FILE_PATH)
+    path = Path(config.LOG_FILE_PATH)
     if not path.exists():
         await ws.close(code=1000)
         return

--- a/scripts/configure_env.py
+++ b/scripts/configure_env.py
@@ -1,0 +1,64 @@
+import os, re, getpass, shutil
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+ENV_PATH = os.path.join(ROOT, ".env")
+EXAMPLE_PATH = os.path.join(ROOT, ".env.example")
+
+def read_env(path):
+    data = {}
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                k, v = line.split("=", 1)
+                data[k] = v
+    return data
+
+def write_env(path, data):
+    order = [
+        "ORACLE_DSN","ORACLE_USER","ORACLE_PASSWORD",
+        "ORACLE_POOL_MIN","ORACLE_POOL_MAX",
+        "JWT_SECRET","JWT_EXPIRES_MIN","LOG_FILE_PATH","VITE_API_BASE"
+    ]
+    with open(path, "w", encoding="utf-8") as f:
+        for k in order:
+            if k in data:
+                f.write(f"{k}={data[k]}\n")
+
+env = read_env(EXAMPLE_PATH)
+env.update(read_env(ENV_PATH))
+
+print("Configuración de credenciales Oracle para .env")
+
+dsn_input = input("Pegá ORACLE_DSN (formato host:puerto/servicio) o dejá vacío para asistente: ").strip()
+dsn_re = re.compile(r"^[^:\s]+:\d+/.+$")
+if dsn_input and dsn_re.match(dsn_input):
+    dsn = dsn_input
+else:
+    host = input(f"Host [{env.get('ORACLE_DSN','melideo19.claro.amx')}]: ").strip() or "melideo19.claro.amx"
+    port = input("Puerto [1521]: ").strip() or "1521"
+    service = input("Servicio [ARTPROD]: ").strip() or "ARTPROD"
+    dsn = f"{host}:{port}/{service}"
+
+user = input(f"Usuario Oracle [{env.get('ORACLE_USER','')}]: ").strip() or env.get("ORACLE_USER","")
+pwd = getpass.getpass("Password Oracle: ").strip()
+
+env["ORACLE_DSN"] = dsn
+env["ORACLE_USER"] = user
+env["ORACLE_PASSWORD"] = pwd
+env.setdefault("ORACLE_POOL_MIN", "1")
+env.setdefault("ORACLE_POOL_MAX", "5")
+env.setdefault("JWT_SECRET", "change_me")
+env.setdefault("JWT_EXPIRES_MIN", "60")
+env.setdefault("LOG_FILE_PATH", "/var/log/app/app.log")
+env.setdefault("VITE_API_BASE", "/api")
+
+if os.path.exists(ENV_PATH):
+    shutil.copyfile(ENV_PATH, ENV_PATH + ".bak")
+write_env(ENV_PATH, env)
+
+print(f"Listo. .env escrito en {ENV_PATH}")
+if os.path.exists(ENV_PATH + ".bak"):
+    print(f"Backup: {ENV_PATH}.bak")


### PR DESCRIPTION
## Summary
- ignore local env files and backups
- provide `.env.example` and interactive configurator
- load backend settings from dotenv
- document environment setup and endpoints

## Testing
- `python3 scripts/configure_env.py`
- `pre-commit run --files .gitignore .env.example scripts/configure_env.py api/app/core/config.py api/app/core/security.py api/app/db/oracle.py api/app/main.py api/app/routers/stream.py README.md`
- `python3 - <<'PY'
import importlib
c = importlib.import_module('api.app.core.config')
print('DSN', c.ORACLE_DSN)
print('USER', c.ORACLE_USER)
print('POOL_MIN', c.ORACLE_POOL_MIN)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c8163faf30832ca31c9e1a4589af26